### PR TITLE
Raise sensible error when user incorrectly uses the #chain methods block

### DIFF
--- a/lib/chain_it.rb
+++ b/lib/chain_it.rb
@@ -1,4 +1,6 @@
 class ChainIt
+  INVALID_RESULT_MSG = "ChainIt#chain block must return both #value and #failure? aware object.\n Check documentation: https://github.com/spark-solutions/chain_it#usage"
+
   def chain
     if @skip_next
       @skip_next = false
@@ -7,26 +9,43 @@ class ChainIt
 
     return self if @skip
     @skip_next = false
-    @result = yield @result&.value
-    @skip = true if @result.failure?
+
+    @result = yield result_value
+    @skip = true if result_failure?
     self
   end
 
   def skip_next
     return self if @skip
-    @skip_next = yield @result&.value
+    @skip_next = yield result_value
     self
   end
 
   def on_error
     return self unless @skip
-    yield @result&.value
+    yield result_value
     @skip = false
     self
   end
 
   def result
     @result
+  end
+
+  private
+
+  def handle_wrong_result_api
+    yield
+  rescue NoMethodError
+    raise StandardError.new INVALID_RESULT_MSG
+  end
+
+  def result_value
+    handle_wrong_result_api { @result&.value }
+  end
+
+  def result_failure?
+    handle_wrong_result_api { @result.failure? }
   end
 end
 

--- a/spec/chain_it_spec.rb
+++ b/spec/chain_it_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe ChainIt do
     it 'always returns it\'s receiver' do
       expect(subject.chain { service_object.call }).to eq subject
     end
+
+    context 'when block responds with invalid object' do
+      let(:result_object) { Struct.new('Result') }
+
+      it 'responds with self explanatory error' do
+        expect { subject.chain { service_object.call } }.
+          to raise_error(StandardError, ChainIt::INVALID_RESULT_MSG)
+      end
+    end
   end
 
   describe '#skip_next' do


### PR DESCRIPTION
Since the current version assumes user to explicitly respond with `Result` object on every `#chain` call, it's not hard to make a mistake and end up with not talking much `NoMethodError: undefined method :failure? for class`.

This is the attempt to display more information that the user is not confused about that and decide not to use our stuff